### PR TITLE
Force line endings in shell scripts to LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+﻿*.sh text eol=lf


### PR DESCRIPTION
Needs to be LF since the droplet runs on Linux.
An attempt to get deployment workflow up and running

Co-authored-by: ChatGPT