### PR TITLE
fixed async bug for creating cheps

### DIFF
--- a/src/MiniTwit.Infrastructure/Repositories/AuthorRepository.cs
+++ b/src/MiniTwit.Infrastructure/Repositories/AuthorRepository.cs
@@ -80,14 +80,14 @@ public class AuthorRepository : IAuthorRepository
         }
 
         // Call to utility method that updates the properties of the original author
-        UpdateAuthor(originalAuthor, updatedAuthor);
+        await UpdateAuthor(originalAuthor, updatedAuthor);
 
         // Saves changes
         await _context.SaveChangesAsync();
     }
 
     // Utility method: set the new properties of the Author
-    private void UpdateAuthor(Author originalAuthor, AuthorDTO updatedAuthor)
+    private async Task UpdateAuthor(Author originalAuthor, AuthorDTO updatedAuthor)
     {
         // Sets the new properties
         originalAuthor.Id = updatedAuthor.Id;
@@ -98,7 +98,7 @@ public class AuthorRepository : IAuthorRepository
 
         foreach (var cheep in updatedAuthor.Cheeps)
         {
-            Cheep newCheep = FromCheepDtoToCheep(cheep).Result;
+            Cheep newCheep = await FromCheepDtoToCheep(cheep);
             cheeps.Add(newCheep);
         }
         

--- a/src/MiniTwit.Infrastructure/Repositories/CheepRepository.cs
+++ b/src/MiniTwit.Infrastructure/Repositories/CheepRepository.cs
@@ -163,14 +163,14 @@ public class CheepRepository : ICheepRepository
         }
         
         // Call to utility method that updates the properties of the original cheep
-        UpdateCheep(originalCheep, alteredCheep);
+        await UpdateCheep(originalCheep, alteredCheep);
         
         // Saves changes
         await _context.SaveChangesAsync();
     }
     
     // Utility method: set the new properties of the Cheep
-    private async void UpdateCheep(Cheep originalCheep, CheepDTO alteredCheep)
+    private async Task UpdateCheep(Cheep originalCheep, CheepDTO alteredCheep)
     {
         // Find the author object of the alteredCheep
         var author = await FindAuthor(alteredCheep.AuthorId);

--- a/src/MiniTwit.Web/Controllers/MinitwitApi.cs
+++ b/src/MiniTwit.Web/Controllers/MinitwitApi.cs
@@ -65,13 +65,13 @@ namespace Org.OpenAPITools.Controllers
         [SwaggerOperation("GetFollow")]
         [SwaggerResponse(statusCode: 200, type: typeof(FollowsResponse), description: "Success")]
         [SwaggerResponse(statusCode: 403, type: typeof(ErrorResponse), description: "Unauthorized - Must include correct Authorization header")]
-        public virtual IActionResult GetFollow([FromRoute (Name = "username")][Required]string username, [FromHeader (Name = "Authorization")][Required()]string authorization, [FromQuery (Name = "latest")]int? latest, [FromQuery (Name = "no")]int? no)
+        public virtual async Task<IActionResult> GetFollow([FromRoute (Name = "username")][Required]string username, [FromHeader (Name = "Authorization")][Required()]string authorization, [FromQuery (Name = "latest")]int? latest, [FromQuery (Name = "no")]int? no)
         {  
             _logger.LogInformation("called get follows for user {user}",username);
             // Update latest if provided
             _latestService.SetLatest(latest);
 
-            var author = _authorService.GetAuthorByName(username).Result;
+            var author = await _authorService.GetAuthorByName(username);
             if (author == null)
             {
                 return StatusCode(404);
@@ -164,11 +164,11 @@ namespace Org.OpenAPITools.Controllers
         [SwaggerOperation("GetMessagesPerUser")]
         [SwaggerResponse(statusCode: 200, type: typeof(List<Message>), description: "Success")]
         [SwaggerResponse(statusCode: 403, type: typeof(ErrorResponse), description: "Unauthorized - Must include correct Authorization header")]
-        public virtual IActionResult GetMessagesPerUser([FromHeader (Name = "Authorization")][Required] string authorization, [FromRoute][Required] string username, [FromQuery] int? latest, [FromQuery] int? no)
+        public virtual async Task<IActionResult> GetMessagesPerUser([FromHeader (Name = "Authorization")][Required] string authorization, [FromRoute][Required] string username, [FromQuery] int? latest, [FromQuery] int? no)
         {
             _logger.LogInformation("called get messages per user with username {username} and amount {amount}",username, no ?? 100);
             _latestService.SetLatest(latest);
-            if (_authorService.GetAuthorByName(username).Result == null)
+            if (await _authorService.GetAuthorByName(username) == null)
             {
                 return NotFound();
             }
@@ -198,13 +198,13 @@ namespace Org.OpenAPITools.Controllers
         [ValidateModelState]
         [SwaggerOperation("PostFollow")]
         [SwaggerResponse(statusCode: 403, type: typeof(ErrorResponse), description: "Unauthorized - Must include correct Authorization header")]
-        public virtual IActionResult PostFollow([FromRoute (Name = "username")][Required]string username, [FromHeader (Name = "Authorization")][Required()]string authorization, [FromBody]FollowAction payload, [FromQuery (Name = "latest")]int? latest)
+        public virtual async Task<IActionResult> PostFollow([FromRoute (Name = "username")][Required]string username, [FromHeader (Name = "Authorization")][Required()]string authorization, [FromBody]FollowAction payload, [FromQuery (Name = "latest")]int? latest)
         {
             _logger.LogInformation("called fllws post as {user} who wants to {fllws}", username, payload);
             _latestService.SetLatest(latest);
 
             // Get the author by username
-            var author = _authorService.GetAuthorByName(username).Result;
+            var author = await _authorService.GetAuthorByName(username);
             if (author == null)
             {
                 return StatusCode(404);
@@ -217,7 +217,7 @@ namespace Org.OpenAPITools.Controllers
             // Handle follow/unfollow action
             if (!string.IsNullOrEmpty(payload.Follow))
             {
-                _authorService.Follow(username, payload.Follow).Wait();
+                await _authorService.Follow(username, payload.Follow);
             }
             else if (!string.IsNullOrEmpty(payload.Unfollow))
             {
@@ -243,18 +243,18 @@ namespace Org.OpenAPITools.Controllers
         [ValidateModelState]
         [SwaggerOperation("PostMessagesPerUser")]
         [SwaggerResponse(statusCode: 403, type: typeof(ErrorResponse), description: "Unauthorized - Must include correct Authorization header")]
-        public virtual IActionResult PostMessagesPerUser([FromHeader (Name = "Authorization")][Required()]string authorization, [FromRoute][Required] string username, [FromQuery] int? latest, [FromBody]PostMessage payload)
+        public virtual async Task<IActionResult> PostMessagesPerUser([FromHeader (Name = "Authorization")][Required()]string authorization, [FromRoute][Required] string username, [FromQuery] int? latest, [FromBody]PostMessage payload)
         {
             _logger.LogInformation("called msgs post with {user} and content {content}",username, payload.Content);
             _latestService.SetLatest(latest);
-            var author =  _authorService.GetAuthorByName(username).Result;
+            var author = await _authorService.GetAuthorByName(username);
             if (author == null)
             {
                 return StatusCode(404);
             }
             var cheep = new CheepDTO() { AuthorId = author.Id,Text = payload.Content,CreatedAt = DateTime.UtcNow};
             
-            _cheepService.CreateCheepFromDTO(cheep);
+            await _cheepService.CreateCheepFromDTO(cheep);
 
             return StatusCode(204);
         }


### PR DESCRIPTION
fail message:
info: Org.OpenAPITools.Controllers.MinitwitApiController[0] called msgs post with Matha Nicoulin and content “Good-bye,” he answered, brusquely; then with artificial stimulants. info: Microsoft.EntityFrameworkCore.Database.Command[20101] Executed DbCommand (2ms) [Parameters=[@__name_0='?' (Size = 255)], CommandType='Text', CommandTimeout='30'] SELECT a.Id, a.AccessFailedCount, a.ConcurrencyStamp, a.Email, a.EmailConfirmed, a.Following, a.LockoutEnabled, a.LockoutEnd, a.Name, a.NormalizedEmail, a.NormalizedUserName, a.PasswordHash, a.PhoneNumber, a.PhoneNumberConfirmed, a.SecurityStamp, a.TwoFactorEnabled, a.UserName, c.CheepId, c.AuthorId, c.Date, c.LikedBy, c.Text FROM AspNetUsers AS a LEFT JOIN Cheeps AS c ON a.Id = c.AuthorId WHERE a.Name = @__name_0 ORDER BY a.Id fail: Microsoft.EntityFrameworkCore.Database.Command[20102] Failed executing DbCommand (0ms) [Parameters=[@__authorId_0='?' (Size = 255)], CommandType='Text', CommandTimeout='30'] SELECT a.Id, a.AccessFailedCount, a.ConcurrencyStamp, a.Email, a.EmailConfirmed, a.Following, a.LockoutEnabled, a.LockoutEnd, a.Name, a.NormalizedEmail, a.NormalizedUserName, a.PasswordHash, a.PhoneNumber, a.PhoneNumberConfirmed, a.SecurityStamp, a.TwoFactorEnabled, a.UserName FROM AspNetUsers AS a WHERE a.Id = @__authorId_0 LIMIT 1 fail: Microsoft.EntityFrameworkCore.Query[10100] An exception occurred while iterating over the results of a query for context type 'MiniTwit.Infrastructure.Data.MiniTwitDBContext'. System.InvalidOperationException: Connection must be Open; current state is Closed at MySqlConnector.MySqlConnection.get_Session() in /_/src/MySqlConnector/MySqlConnection.cs:line 887 at MySqlConnector.Core.ICancellableCommandExtensions.ResetCommandTimeout(ICancellableCommand command) in /_/src/MySqlConnector/Core/ICancellableCommand.cs:line 42 at MySqlConnector.MySqlCommand.ExecuteReaderAsync(CommandBehavior behavior, IOBehavior ioBehavior, CancellationToken cancellationToken) in /_/src/MySqlConnector/MySqlCommand.cs:line 355 at MySqlConnector.MySqlCommand.ExecuteDbDataReaderAsync(CommandBehavior behavior, CancellationToken cancellationToken) in /_/src/MySqlConnector/MySqlCommand.cs:line 350 at Microsoft.EntityFrameworkCore.Storage.RelationalCommand.ExecuteReaderAsync(RelationalCommandParameterObject parameterObject, CancellationToken cancellationToken) at Microsoft.EntityFrameworkCore.Storage.RelationalCommand.ExecuteReaderAsync(RelationalCommandParameterObject parameterObject, CancellationToken cancellationToken) at Microsoft.EntityFrameworkCore.Query.Internal.SingleQueryingEnumerable1.AsyncEnumerator.InitializeReaderAsync(AsyncEnumerator enumerator, CancellationToken cancellationToken) at Pomelo.EntityFrameworkCore.MySql.Storage.Internal.MySqlExecutionStrategy.ExecuteAsync[TState,TResult](TState state, Func4 operation, Func4 verifySucceeded, CancellationToken cancellationToken) at Microsoft.EntityFrameworkCore.Query.Internal.SingleQueryingEnumerable1.AsyncEnumerator.MoveNextAsync() System.InvalidOperationException: Connection must be Open; current state is Closed at MySqlConnector.MySqlConnection.get_Session() in /_/src/MySqlConnector/MySqlConnection.cs:line 887 at MySqlConnector.Core.ICancellableCommandExtensions.ResetCommandTimeout(ICancellableCommand command) in /_/src/MySqlConnector/Core/ICancellableCommand.cs:line 42 at MySqlConnector.MySqlCommand.ExecuteReaderAsync(CommandBehavior behavior, IOBehavior ioBehavior, CancellationToken cancellationToken) in /_/src/MySqlConnector/MySqlCommand.cs:line 355 at MySqlConnector.MySqlCommand.ExecuteDbDataReaderAsync(CommandBehavior behavior, CancellationToken cancellationToken) in /_/src/MySqlConnector/MySqlCommand.cs:line 350 at Microsoft.EntityFrameworkCore.Storage.RelationalCommand.ExecuteReaderAsync(RelationalCommandParameterObject parameterObject, CancellationToken cancellationToken) at Microsoft.EntityFrameworkCore.Storage.RelationalCommand.ExecuteReaderAsync(RelationalCommandParameterObject parameterObject, CancellationToken cancellationToken) at Microsoft.EntityFrameworkCore.Query.Internal.SingleQueryingEnumerable1.AsyncEnumerator.InitializeReaderAsync(AsyncEnumerator enumerator, CancellationToken cancellationToken) at Pomelo.EntityFrameworkCore.MySql.Storage.Internal.MySqlExecutionStrategy.ExecuteAsync[TState,TResult](TState state, Func4 operation, Func4 verifySucceeded, CancellationToken cancellationToken) at Microsoft.EntityFrameworkCore.Query.Internal.SingleQueryingEnumerable1.AsyncEnumerator.MoveNextAsync()